### PR TITLE
Add Zigbee skeleton for ESP32-C6

### DIFF
--- a/include/esp_zb_light.h
+++ b/include/esp_zb_light.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "esp_zigbee_core.h"
+
+#define INSTALLCODE_POLICY_ENABLE       false
+#define ED_AGING_TIMEOUT                ESP_ZB_ED_AGING_TIMEOUT_64MIN
+#define ED_KEEP_ALIVE                   3000
+#define HA_ESP_LIGHT_ENDPOINT           10
+#define ESP_ZB_PRIMARY_CHANNEL_MASK     ESP_ZB_TRANSCEIVER_ALL_CHANNELS_MASK
+
+#define ESP_MANUFACTURER_NAME "\x09""ESPRESSIF"
+#define ESP_MODEL_IDENTIFIER "\x07"CONFIG_IDF_TARGET
+
+#define ESP_ZB_ZED_CONFIG() { \
+        .esp_zb_role = ESP_ZB_DEVICE_TYPE_ED, \
+        .install_code_policy = INSTALLCODE_POLICY_ENABLE, \
+        .nwk_cfg.zed_cfg = { \
+            .ed_timeout = ED_AGING_TIMEOUT, \
+            .keep_alive = ED_KEEP_ALIVE, \
+        }, \
+    }
+
+#define ESP_ZB_DEFAULT_RADIO_CONFIG() { \
+        .radio_mode = ZB_RADIO_MODE_NATIVE, \
+    }
+
+#define ESP_ZB_DEFAULT_HOST_CONFIG() { \
+        .host_connection_mode = ZB_HOST_CONNECTION_MODE_NONE, \
+    }

--- a/include/light_driver.h
+++ b/include/light_driver.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void light_driver_init(bool power);
+void light_driver_set_power(bool power);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,19 +1,21 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
 build_flags = -DDEBUG
+build_src_filter = +<src/main.cpp> -<zb_src/*>
+custom_src_dir = src
+extra_scripts = pre:scripts/set_src_dir.py
 lib_deps =
-    knolleary/PubSubClient@^2.8    
-	https://github.com/prampec/IotWebConf
+    knolleary/PubSubClient@^2.8
+    https://github.com/prampec/IotWebConf
+
+[env:esp32c6]
+platform = espressif32
+board = esp32-c6-devkitc-1
+framework = espidf
+monitor_speed = 115200
+build_src_filter = +<zb_src/main.c> +<zb_src/relay_driver.c> -<src/*>
+custom_src_dir = zb_src
+extra_scripts = pre:scripts/set_src_dir.py

--- a/scripts/set_src_dir.py
+++ b/scripts/set_src_dir.py
@@ -1,0 +1,5 @@
+Import("env")
+
+src_dir = env.GetProjectOption("custom_src_dir")
+if src_dir:
+    env.Replace(PROJECT_SRC_DIR=env.Dir(src_dir).abspath)

--- a/zb_src/CMakeLists.txt
+++ b/zb_src/CMakeLists.txt
@@ -1,0 +1,6 @@
+# This file was automatically generated for projects
+# without default 'CMakeLists.txt' file.
+
+FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
+
+idf_component_register(SRCS ${app_sources})

--- a/zb_src/idf_component.yml
+++ b/zb_src/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  espressif/esp-zboss-lib: "~1.6.0"
+  espressif/esp-zigbee-lib: "~1.6.0"
+  idf:
+    version: ">=5.0.0"

--- a/zb_src/main.c
+++ b/zb_src/main.c
@@ -1,0 +1,55 @@
+#include "esp_zb_light.h"
+#include "light_driver.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "ha/esp_zigbee_ha_standard.h"
+
+static const char *TAG = "ZB_ZONE";
+
+static esp_err_t zb_attribute_handler(const esp_zb_zcl_set_attr_value_message_t *message)
+{
+    if (!message) return ESP_FAIL;
+    if (message->info.dst_endpoint == HA_ESP_LIGHT_ENDPOINT &&
+        message->info.cluster == ESP_ZB_ZCL_CLUSTER_ID_ON_OFF &&
+        message->attribute.id == ESP_ZB_ZCL_ATTR_ON_OFF_ON_OFF_ID &&
+        message->attribute.data.type == ESP_ZB_ZCL_ATTR_TYPE_BOOL) {
+        bool state = *(bool *)message->attribute.data.value;
+        ESP_LOGI(TAG, "Zone set to %s", state ? "ON" : "OFF");
+        light_driver_set_power(state);
+    }
+    return ESP_OK;
+}
+
+static void esp_zb_task(void *pv)
+{
+    esp_zb_cfg_t zb_nwk_cfg = ESP_ZB_ZED_CONFIG();
+    esp_zb_init(&zb_nwk_cfg);
+
+    esp_zb_on_off_light_cfg_t light_cfg = ESP_ZB_DEFAULT_ON_OFF_LIGHT_CONFIG();
+    esp_zb_ep_list_t *ep = esp_zb_on_off_light_ep_create(HA_ESP_LIGHT_ENDPOINT, &light_cfg);
+
+    zcl_basic_manufacturer_info_t info = {
+        .manufacturer_name = ESP_MANUFACTURER_NAME,
+        .model_identifier = ESP_MODEL_IDENTIFIER,
+    };
+    esp_zcl_utility_add_ep_basic_manufacturer_info(ep, HA_ESP_LIGHT_ENDPOINT, &info);
+    esp_zb_device_register(ep);
+
+    esp_zb_core_action_handler_register(zb_attribute_handler);
+    esp_zb_set_primary_network_channel_set(ESP_ZB_PRIMARY_CHANNEL_MASK);
+    ESP_ERROR_CHECK(esp_zb_start(false));
+    esp_zb_stack_main_loop();
+}
+
+void app_main(void)
+{
+    esp_zb_platform_config_t config = {
+        .radio_config = ESP_ZB_DEFAULT_RADIO_CONFIG(),
+        .host_config = ESP_ZB_DEFAULT_HOST_CONFIG(),
+    };
+    ESP_ERROR_CHECK(nvs_flash_init());
+    ESP_ERROR_CHECK(esp_zb_platform_config(&config));
+    xTaskCreate(esp_zb_task, "Zigbee_main", 4096, NULL, 5, NULL);
+}

--- a/zb_src/relay_driver.c
+++ b/zb_src/relay_driver.c
@@ -1,0 +1,49 @@
+#include "driver/gpio.h"
+#include "light_driver.h"
+
+#define DATA_PIN 14
+#define CLOCK_PIN 13
+#define LATCH_PIN 12
+#define OE_PIN 5
+
+static uint16_t shift_state = 0;
+
+static void write_shift_register(void)
+{
+    gpio_set_level(LATCH_PIN, 0);
+    for (int i = 15; i >= 0; --i) {
+        gpio_set_level(CLOCK_PIN, 0);
+        gpio_set_level(DATA_PIN, (shift_state >> i) & 1);
+        gpio_set_level(CLOCK_PIN, 1);
+    }
+    gpio_set_level(LATCH_PIN, 1);
+}
+
+static void set_relay(int index, bool active)
+{
+    if (active) shift_state |= (1 << index);
+    else shift_state &= ~(1 << index);
+    write_shift_register();
+}
+
+void light_driver_init(bool power)
+{
+    gpio_reset_pin(DATA_PIN);
+    gpio_set_direction(DATA_PIN, GPIO_MODE_OUTPUT);
+    gpio_reset_pin(CLOCK_PIN);
+    gpio_set_direction(CLOCK_PIN, GPIO_MODE_OUTPUT);
+    gpio_reset_pin(LATCH_PIN);
+    gpio_set_direction(LATCH_PIN, GPIO_MODE_OUTPUT);
+    gpio_reset_pin(OE_PIN);
+    gpio_set_direction(OE_PIN, GPIO_MODE_OUTPUT);
+    gpio_set_level(OE_PIN, 0);
+
+    shift_state = 0;
+    write_shift_register();
+    light_driver_set_power(power);
+}
+
+void light_driver_set_power(bool power)
+{
+    set_relay(0, power); // control first zone for now
+}


### PR DESCRIPTION
## Summary
- provide basic zigbee headers and driver stubs
- add zigbee main application in `zb_src`
- configure platformio with extra script to select source directory per env

## Testing
- `pio run -e esp32dev`
- `pio run -e esp32c6` *(fails: Missing `zb_src` sources)*

------
https://chatgpt.com/codex/tasks/task_e_68514f48f34c832bb80d8db9ea5ff220